### PR TITLE
fix(theme): updates only after api call

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,9 +59,9 @@ export function AppWrapper({ children }: { children: React.ReactNode }) {
             .then((res) => {
                 setProfile(res.data)
                 setTheme!(res.data["Label"] === "least_interested" ? ThemeEnum.RSK : res.data["Label"] === "highly_interested" ? ThemeEnum.PRE : ThemeEnum.RGL)
+                setIsLoggedIn(true)
             })
             .catch(() => {})
-          setIsLoggedIn(true)
         } else {
           handleSignOut()
         }

--- a/frontend/src/containers/login/Login.tsx
+++ b/frontend/src/containers/login/Login.tsx
@@ -58,10 +58,10 @@ export function LoginFields() {
         .then((res) => {
             setProfile!(res.data)
             setTheme!(res.data["Label"] === "least_interested" ? ThemeEnum.RSK : res.data["Label"] === "highly_interested" ? ThemeEnum.PRE : ThemeEnum.RGL)
+            navigate('/')
         })
         .catch(() => {})
         setIsLoggedIn!(true)
-        navigate('/')
     }
     
     return (


### PR DESCRIPTION
### Fixes/Implements #23 

## Description

- The mention of `navigation`, or the `isLoggedIn` variable is updated only after a successful fetch of API data.
- Must be looked into further after the implementation of backend authentication.

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
